### PR TITLE
Add ability to check shapes with wildcards

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -214,7 +214,9 @@ def assert_shape(
   errors = []
   for idx, (x, expected) in enumerate(zip(inputs, expected_shapes)):
     shape = getattr(x, "shape", ())  # scalars have shape () by definition.
-    if list(shape) != list(expected):
+    if not (
+        len(shape) == len(expected)
+        and all(j is None or i == j for i, j in zip(shape, expected))):
       errors.append((idx, shape, expected))
 
   if errors:


### PR DESCRIPTION
I often find myself writing the following sort of thing:
```python
chex.assert_rank(x, 2)
x.shape[1] == num_actions, "some custom message ..."
```
It would be nice to be able to simply check the shape with a wildcard, i.e.
```python
chex.assert_shape(x, (None, num_actions))
```

What do you think?