### PR TITLE
Use type() instead of __class__ in dataclass_test.py

### DIFF
--- a/chex/_src/dataclass_test.py
+++ b/chex/_src/dataclass_test.py
@@ -303,7 +303,6 @@ class DataclassesTest(parameterized.TestCase):
   def test_tuple_rev_conversion(self, frozen):
     obj = dummy_dataclass(frozen=frozen)
     asserts.assert_tree_all_close(type(obj).from_tuple(obj.to_tuple()), obj)
-    self.assertTrue(0)
 
   @parameterized.named_parameters(
       ('frozen', True),

--- a/chex/_src/dataclass_test.py
+++ b/chex/_src/dataclass_test.py
@@ -302,7 +302,8 @@ class DataclassesTest(parameterized.TestCase):
   )
   def test_tuple_rev_conversion(self, frozen):
     obj = dummy_dataclass(frozen=frozen)
-    asserts.assert_tree_all_close(obj.__class__.from_tuple(obj.to_tuple()), obj)
+    asserts.assert_tree_all_close(type(obj).from_tuple(obj.to_tuple()), obj)
+    self.assertTrue(0)
 
   @parameterized.named_parameters(
       ('frozen', True),


### PR DESCRIPTION
A tiny change to test new Copybara migrations.