### PR TITLE
Use dataclass_transform to help type checkers with @chex.dataclass

### DIFF
--- a/chex/_src/dataclass.py
+++ b/chex/_src/dataclass.py
@@ -17,9 +17,11 @@
 import collections
 import dataclasses
 import functools
+import typing
 
 from absl import logging
 import jax
+import typing_extensions
 
 
 FrozenInstanceError = dataclasses.FrozenInstanceError
@@ -82,6 +84,14 @@ def mappable_dataclass(cls):
   return cls
 
 
+_T = typing.TypeVar("_T")
+
+
+@typing_extensions.dataclass_transform(
+  eq_default=True,
+  order_default=False,
+  field_specifiers=(dataclasses.Field, dataclasses.field),
+)
 def dataclass(
     cls=None,
     *,
@@ -92,7 +102,7 @@ def dataclass(
     unsafe_hash=False,
     frozen=False,
     mappable_dataclass=True,  # pylint: disable=redefined-outer-name
-):
+) -> typing.Callable[[typing.Type[_T]], typing.Type[_T]]:
   """JAX-friendly wrapper for :py:func:`dataclasses.dataclass`.
 
   This wrapper class registers new dataclasses with JAX so that tree utils

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,3 +5,4 @@ jax>=0.1.55
 jaxlib>=0.1.37
 numpy>=1.18.0
 toolz>=0.9.0
+typing_extensions>=4.2.0


### PR DESCRIPTION
closes #155 

I basically copied this example: https://peps.python.org/pep-0681/#id1

Tested with pyright/pylance.

I had to specify a return type for `chex.dataclass` because otherwise pyright/pylance is ignoring it completely if arguments are passed to it (like `chex.dataclass(eq=False)`), but if it's used bare (just `chex.dataclass` without any parentheses) then it also works without the return type annotation.

There is a (expected) test failure from pytype:
```
FAILED: /home/tmk/dev/python/chex/.pytype/pyi/chex/_src/dataclass.pyi 
/tmp/chex-env/bin/python3 -m pytype.single --imports_info /home/tmk/dev/python/chex/.pytype/imports/chex._src.dataclass.imports --module-name chex._src.dataclass --platform linux -V 3.9 -o /home/tmk/dev/python/chex/.pytype/pyi/chex/_src/dataclass.pyi --analyze-annotated --nofail --quick /home/tmk/dev/python/chex/chex/_src/dataclass.py
File "/home/tmk/dev/python/chex/chex/_src/dataclass.py", line 90, in <module>: typing_extensions.dataclass_transform not supported yet [not-supported-yet]
```
I'm not sure how to deal with that.

There is also not really a way to write tests for this...

cc @hbq1 