### PR TITLE
Update requirements: increase minimal jax, jaxlib

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 absl-py>=0.9.0
 typing_extensions>=4.2.0; python_version<"3.11"
 dm-tree>=0.1.5
-jax>=0.1.55
-jaxlib>=0.1.37
+jax>=0.4.1
+jaxlib>=0.4.1
 numpy>=1.18.0
 toolz>=0.9.0


### PR DESCRIPTION
Using the new jax.Array objects requires a higher version of Jax
Jaxlib also requires numpy 1.20 but not sure if its necessary to put that in this requirements file too