### PR TITLE
Add size based assertions

### DIFF
--- a/chex/__init__.py
+++ b/chex/__init__.py
@@ -164,6 +164,7 @@ __all__ = (
     "assert_trees_all_equal",
     "assert_trees_all_equal_comparator",
     "assert_trees_all_equal_dtypes",
+    "assert_trees_all_equal_sizes",
     "assert_trees_all_equal_shapes",
     "assert_trees_all_equal_shapes_and_dtypes",
     "assert_trees_all_equal_structs",

--- a/chex/__init__.py
+++ b/chex/__init__.py
@@ -23,6 +23,7 @@ from chex._src.asserts import assert_axis_dimension_lteq
 from chex._src.asserts import assert_devices_available
 from chex._src.asserts import assert_equal
 from chex._src.asserts import assert_equal_rank
+from chex._src.asserts import assert_equal_size
 from chex._src.asserts import assert_equal_shape
 from chex._src.asserts import assert_equal_shape_prefix
 from chex._src.asserts import assert_equal_shape_suffix
@@ -39,6 +40,7 @@ from chex._src.asserts import assert_scalar_in
 from chex._src.asserts import assert_scalar_negative
 from chex._src.asserts import assert_scalar_non_negative
 from chex._src.asserts import assert_scalar_positive
+from chex._src.asserts import assert_size
 from chex._src.asserts import assert_shape
 from chex._src.asserts import assert_tpu_available
 from chex._src.asserts import assert_tree_all_close  # Deprecated
@@ -58,6 +60,7 @@ from chex._src.asserts import assert_trees_all_close_ulp
 from chex._src.asserts import assert_trees_all_equal
 from chex._src.asserts import assert_trees_all_equal_comparator
 from chex._src.asserts import assert_trees_all_equal_dtypes
+from chex._src.asserts import assert_trees_all_equal_sizes
 from chex._src.asserts import assert_trees_all_equal_shapes
 from chex._src.asserts import assert_trees_all_equal_shapes_and_dtypes
 from chex._src.asserts import assert_trees_all_equal_structs
@@ -124,6 +127,7 @@ __all__ = (
     "assert_devices_available",
     "assert_equal",
     "assert_equal_rank",
+    "assert_equal_size",
     "assert_equal_shape",
     "assert_equal_shape_prefix",
     "assert_equal_shape_suffix",
@@ -140,6 +144,7 @@ __all__ = (
     "assert_scalar_negative",
     "assert_scalar_non_negative",
     "assert_scalar_positive",
+    "assert_size",
     "assert_shape",
     "assert_tpu_available",
     "assert_tree_all_close",  # Deprecated

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,6 +14,7 @@ Assertions
     assert_devices_available
     assert_equal
     assert_equal_rank
+    assert_equal_size
     assert_equal_shape
     assert_equal_shape_prefix
     assert_equal_shape_suffix
@@ -30,6 +31,7 @@ Assertions
     assert_scalar_negative
     assert_scalar_non_negative
     assert_scalar_positive
+    assert_size
     assert_shape
     assert_tpu_available
     assert_tree_all_finite
@@ -45,6 +47,7 @@ Assertions
     assert_trees_all_equal
     assert_trees_all_equal_comparator
     assert_trees_all_equal_dtypes
+    assert_trees_all_equal_sizes
     assert_trees_all_equal_shapes
     assert_trees_all_equal_shapes_and_dtypes
     assert_trees_all_equal_structs
@@ -94,6 +97,7 @@ Tree Assertions
 .. autofunction:: assert_trees_all_equal
 .. autofunction:: assert_trees_all_equal_comparator
 .. autofunction:: assert_trees_all_equal_dtypes
+.. autofunction:: assert_trees_all_equal_sizes
 .. autofunction:: assert_trees_all_equal_shapes
 .. autofunction:: assert_trees_all_equal_shapes_and_dtypes
 .. autofunction:: assert_trees_all_equal_structs
@@ -110,6 +114,7 @@ Generic Assertions
 .. autofunction:: assert_axis_dimension_lteq
 .. autofunction:: assert_equal
 .. autofunction:: assert_equal_rank
+.. autofunction:: assert_equal_size
 .. autofunction:: assert_equal_shape
 .. autofunction:: assert_equal_shape_prefix
 .. autofunction:: assert_equal_shape_suffix
@@ -124,6 +129,7 @@ Generic Assertions
 .. autofunction:: assert_scalar_negative
 .. autofunction:: assert_scalar_non_negative
 .. autofunction:: assert_scalar_positive
+.. autofunction:: assert_size
 .. autofunction:: assert_shape
 .. autofunction:: assert_type
 


### PR DESCRIPTION
Adds size based assertions: `assert_size`, `assert_equal_size`, `assert_trees_all_equal_sizes`. The additions are based on the `shape` based equivalents. 

These assertions are useful for one of my own use cases, so thought they might be a nice addition to the package.