### PR TITLE
Fix deprecated typing aliases to use collections.abc

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -16,10 +16,11 @@
 
 import collections
 import collections.abc
+from collections.abc import Sequence
 import functools
 import inspect
 import traceback
-from typing import Any, Callable, List, Optional, Sequence, Set, Union, cast
+from typing import Any, Callable, List, Optional, Set, Union, cast
 import unittest
 from unittest import mock
 

--- a/chex/_src/asserts_chexify_test.py
+++ b/chex/_src/asserts_chexify_test.py
@@ -19,7 +19,8 @@ import re
 import sys
 import threading
 import time
-from typing import Any, Optional, Sequence, Type
+from typing import Any, Optional, Type
+from collections.abc import Sequence
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/chex/_src/asserts_internal.py
+++ b/chex/_src/asserts_internal.py
@@ -24,12 +24,12 @@ Instead, consider opening an issue on GitHub and describing your use case.
 
 import collections
 import collections.abc
-from collections.abc import Hashable
+from collections.abc import Hashable, Sequence
 import functools
 import re
 import threading
 import traceback
-from typing import Any, Sequence, Union, Callable, List, Optional, Set, Tuple, Type
+from typing import Any, Union, Callable, List, Optional, Set, Tuple, Type
 
 from absl import logging
 from chex._src import pytypes

--- a/chex/_src/dataclass_test.py
+++ b/chex/_src/dataclass_test.py
@@ -20,7 +20,8 @@ import copy
 import dataclasses
 import pickle
 import sys
-from typing import Any, Generic, Mapping, TypeVar
+from typing import Any, Generic, TypeVar
+from collections.abc import Mapping
 import unittest
 
 from absl.testing import absltest

--- a/chex/_src/fake.py
+++ b/chex/_src/fake.py
@@ -25,7 +25,8 @@ import functools
 import inspect
 import os
 import re
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Optional, Union
+from collections.abc import Iterable
 from unittest import mock
 from absl import flags
 import jax

--- a/chex/_src/pytypes.py
+++ b/chex/_src/pytypes.py
@@ -14,7 +14,8 @@
 # ==============================================================================
 """Type definitions to use for type annotations."""
 
-from typing import Any, Iterable, Mapping, Sequence, Union
+from typing import Any, Union
+from collections.abc import Iterable, Mapping, Sequence
 
 import jax
 import numpy as np

--- a/chex/_src/restrict_backends.py
+++ b/chex/_src/restrict_backends.py
@@ -29,7 +29,8 @@ at the end of the first iteration, the system can detect any overlooked cases.
 """
 import contextlib
 import functools
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional
+from collections.abc import Sequence
 
 from jax._src import compiler
 

--- a/chex/_src/variants.py
+++ b/chex/_src/variants.py
@@ -18,7 +18,8 @@ import enum
 import functools
 import inspect
 import itertools
-from typing import Any, Sequence
+from typing import Any
+from collections.abc import Sequence
 import unittest
 
 from absl import flags


### PR DESCRIPTION
This PR updates deprecated typing aliases to their modern collections.abc counterparts to follow PEP 585 and avoid future Python 3.14+ issues and beartype warnings.

Changes:
- Replace imports like `from typing import Iterator, Sequence, Mapping, Iterable` with `from collections.abc import Iterator, Sequence, Mapping, Iterable` in chex/_src modules.

Testing:
- Installed in editable mode with `python -m pip install -e ".[dev]"`.
- Ran `python -m pytest` on Windows / Python 3.14.2. One async checkify test aborted with a JAX runtime error that appears environment-specific; no failures observed that seem related to these type-hint edits.