### PR TITLE
Add assert_not_both_not_none (fixes #393)

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -248,6 +248,20 @@ def assert_not_both_none(first: Any, second: Any) -> None:
     raise AssertionError(
         "At least one of the arguments must be different from `None`.")
 
+@_static_assertion
+def assert_not_both_not_none(first: Any, second: Any) -> None:
+  """Checks that not both arguments are non-None.
+
+  Args:
+    first: A first object.
+    second: A second object.
+
+  Raises:
+    AssertionError: If both ``first`` and ``second`` are not None.
+  """
+  if first is not None and second is not None:
+    raise AssertionError(
+        "At most one of the arguments may be different from `None`.")
 
 @_static_assertion
 def assert_exactly_one_is_none(first: Any, second: Any) -> None:

--- a/chex/_src/asserts_test.py
+++ b/chex/_src/asserts_test.py
@@ -1860,7 +1860,15 @@ class EqualAssertionsTest(parameterized.TestCase):
     with self.assertRaises(AssertionError):
       asserts.assert_equal(first, second)
 
+class NotNoneAssertionsTest(parameterized.TestCase):
 
+    def test_assert_not_both_not_none(self):
+        asserts.assert_not_both_not_none(None, None)
+        asserts.assert_not_both_not_none(1, None)
+        asserts.assert_not_both_not_none(None, 1)
+
+        with self.assertRaises(AssertionError):
+            asserts.assert_not_both_not_none(1, 2)
 class IsDivisibleTest(parameterized.TestCase):
 
   def test_assert_is_divisible(self):


### PR DESCRIPTION
This PR adds a new static assertion `assert_not_both_not_none` requested in issue #393.

Behavior validation:
- (None, None) → allowed
- (value, None) → allowed
- (None, value) → allowed
- (value, value) → AssertionError

Implemented in asserts.py and validated via existing assertion tests.
All local tests pass aside from an unrelated chexify docstring issue which occurs on main as well.