### PR TITLE
Docs: Fix broken citation link in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,16 @@ Citing Chex
 
 This repository is part of the `DeepMind JAX Ecosystem <https://deepmind.com/blog/article/using-jax-to-accelerate-our-research>`_.
 
-To cite Chex please use the `DeepMind JAX Ecosystem citation <https://github.com/google-deepmind/jax/blob/main/deepmind2020jax.txt>`_.
+To cite Chex please use the citation:
+
+.. code-block:: bibtex
+
+   @software{deepmind2020jax,
+     title = {The {D}eep{M}ind {JAX} {E}cosystem},
+     author = {DeepMind and Babuschkin, Igor and Baumli, Kate and Bell, Alison and Bhupatiraju, Surya and Bruce, Jake and Buchlovsky, Peter and Budden, David and Cai, Trevor and Clark, Aidan and Danihelka, Ivo and Dedieu, Antoine and Fantacci, Claudio and Godwin, Jonathan and Jones, Chris and Hemsley, Ross and Hennigan, Tom and Hessel, Matteo and Hou, Shaobo and Kapturowski, Steven and Keck, Thomas and Kemaev, Iurii and King, Michael and Kunesch, Markus and Martens, Lena and Merzic, Hamza and Mikulik, Vladimir and Norman, Tamara and Papamakarios, George and Quan, John and Ring, Roman and Ruiz, Francisco and Sanchez, Alvaro and Sartran, Laurent and Schneider, Rosalia and Sezener, Eren and Spencer, Stephen and Srinivasan, Srivatsan and Stanojevi\'{c}, Milo\v{s} and Stokowiec, Wojciech and Wang, Luyu and Zhou, Guangyao and Viola, Fabio},
+     url = {http://github.com/deepmind},
+     year = {2020},
+   }
 
 Contribute
 ----------


### PR DESCRIPTION
Resolves #329. Replaces the broken citation link with the full BibTeX citation, consistent with the README.