### PR TITLE
Fix: Exclude test files from package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,8 @@ docs = [
     "sphinxcontrib-katex",
 ]
 
-[tool.setuptools.packages.find]
-include = ["README.md", "LICENSE"]
-exclude = ["*_test.py"]
+[tool.flit.sdist]
+exclude = ["**/*_test.py", "**/test_*.py"]
 
 [tool.ruff]
 line-length = 80


### PR DESCRIPTION
Resolves #347. Updates \pyproject.toml\ to correctly exclude test files (\*_test.py\) from the built package using \[tool.flit.sdist]\ configuration.