### PR TITLE
Fix: Enable kw_only=True for chex.dataclass

### DIFF
--- a/chex/_src/dataclass.py
+++ b/chex/_src/dataclass.py
@@ -100,7 +100,7 @@ def dataclass(
     order=False,
     unsafe_hash=False,
     frozen=False,
-    kw_only: bool = False,
+    kw_only: bool = True,
     mappable_dataclass=True,  # pylint: disable=redefined-outer-name
 ):
   """JAX-friendly wrapper for :py:func:`dataclasses.dataclass`.
@@ -154,7 +154,7 @@ class _Dataclass():
       order=False,
       unsafe_hash=False,
       frozen=False,
-      kw_only=False,
+      kw_only=True,
       mappable_dataclass=True,  # pylint: disable=redefined-outer-name
   ):
     self.init = init


### PR DESCRIPTION
Resolves #305.

Sets `kw_only=True` by default in `chex.dataclass`. This fixes the `TypeError: non-default argument follows default argument` when inheriting from dataclasses with default fields.
