### PR TITLE
fix: clarify assert_shape error when bare Ellipsis is passed

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -625,6 +625,10 @@ def assert_shape(
       match; if ``expected_shapes`` has wrong type; if shape of ``input`` does
       not match ``expected_shapes``.
   """
+  if expected_shapes is Ellipsis:
+    raise AssertionError(
+        "Error in shape compatibility check: `...` must be wrapped in a tuple, "
+        "e.g. `(...,)` not `...`.")
   if not isinstance(expected_shapes, (list, tuple)):
     raise AssertionError(
         "Error in shape compatibility check: expected shapes should be a list "


### PR DESCRIPTION
Fixes #437

When passing bare `...` to `assert_shape`, the error message says "got Ellipsis" which doesn't help the user understand what went wrong. Added a specific check that tells them `...` needs to be wrapped as `(...,)`.

Tested locally.