### PR TITLE
Fix dtype reported for the second operand in assert_trees_all_equal error message

### DIFF
--- a/chex/_src/asserts.py
+++ b/chex/_src/asserts.py
@@ -1606,7 +1606,7 @@ def _assert_trees_all_equal_static(
       dtype_2 = (
           arr_2.dtype
           if isinstance(arr_2, jax.Array)
-          else np.asarray(arr_1).dtype
+          else np.asarray(arr_2).dtype
       )
       return f"{str(e)} \nOriginal dtypes: {dtype_1}, {dtype_2}"
     return ""

--- a/chex/_src/asserts_test.py
+++ b/chex/_src/asserts_test.py
@@ -946,6 +946,13 @@ class TreeAssertionsTest(parameterized.TestCase):
     with self.assertRaisesRegex(AssertionError, err_regex):
       asserts.assert_trees_all_equal(tree1, tree2)  # Fail: not equal
 
+  def test_assert_trees_all_equal_reports_both_dtypes(self):
+    # The "Original dtypes" line must report each operand's own dtype.
+    tree1 = np.array([1, 2, 3], dtype=np.int8)
+    tree2 = np.array([1, 2, 9], dtype=np.float64)
+    with self.assertRaisesRegex(AssertionError, r'Original dtypes: int8, float64'):
+      asserts.assert_trees_all_equal(tree1, tree2)
+
   def test_assert_trees_all_equal_passes_same_tree(self):
     tree = {
         'a': [jnp.zeros((1,))],


### PR DESCRIPTION
The `err_msg_fn` closure in `_assert_trees_all_equal_static` (`chex/_src/asserts.py`) computes `dtype_2`'s fallback as `np.asarray(arr_1).dtype` instead of `arr_2`:

```python
dtype_2 = (
    arr_2.dtype
    if isinstance(arr_2, jax.Array)
    else np.asarray(arr_1).dtype   # should be arr_2
)
```

So when the second operand isn't a `jax.Array` (a NumPy array / Python scalar), the "Original dtypes" line reports the *first* operand's dtype for both — e.g. `int8, int8` instead of `int8, float64`. The sibling `_assert_trees_all_close_static` and `_assert_trees_all_eq_cmp` both correctly use `arr_2`, confirming this is a typo.

Verified: `chex.assert_trees_all_equal(np.array([1,2,3], np.int8), np.array([1,2,9], np.float64))` now reports `Original dtypes: int8, float64`. Added a regression test.